### PR TITLE
fix: Vercel에서 페이지 컴포넌트 인식 못함 오류

### DIFF
--- a/src/app/(route)/terms/privacy/page.tsx
+++ b/src/app/(route)/terms/privacy/page.tsx
@@ -1,9 +1,11 @@
 import { PrivacyPolicy } from "@/app/features/home/PrivacyPolicy";
 
-export const PrivacyPolicyPage: React.FC = () => {
+const PrivacyPolicyPage: React.FC = () => {
   return (
     <div className="container mx-auto py-10">
       <PrivacyPolicy />
     </div>
   );
 };
+
+export default PrivacyPolicyPage;

--- a/src/app/(route)/terms/service/page.tsx
+++ b/src/app/(route)/terms/service/page.tsx
@@ -1,9 +1,11 @@
 import { TermsOfService } from "@/app/features/home/TermsOfService";
 
-export const TermsOfServicePage: React.FC = () => {
+const TermsOfServicePage: React.FC = () => {
   return (
     <div className="container mx-auto py-10">
       <TermsOfService />
     </div>
   );
 };
+
+export default TermsOfServicePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import { ImgWithTextRight } from "@/app/features/home/ImgWithTextRight";
 import { ImgWithTextAndBtns } from "@/app/features/home/ImgWithTextAndBtns";
 import { KeyFeatures } from "@/app/features/home/KeyFeatures";
 
-export default function Home() {
+const Home: React.FC = () => {
   return (
     <div>
       <ImgWithTextLeft
@@ -39,4 +39,6 @@ export default function Home() {
       <KeyFeatures />
     </div>
   );
-}
+};
+
+export default Home;


### PR DESCRIPTION
- Next.js가 name export 방식을 페이지 컴포넌트로 인식하지 못해 default export로 변경