### PR TITLE
fix: useRouter 훅을 클라이언트 사이드에서만 사용하도록 수정

### DIFF
--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -1,7 +1,15 @@
-export default function MyPage() {
-  return <div>MyPage</div>;
-}
+import dynamic from "next/dynamic";
 
-// 오늘 할 일
-// 1. MyPageLayout에 MyPageHeader 추가
-// 2. MyPage 구현
+// 동적 import를 사용하여 컴포넌트를 클라이언트 사이드에서만 렌더링하도록 설정
+const MyPageHeader = dynamic(
+  () => import("@/app/features/mypage/MyPageHeader"),
+  { ssr: false },
+);
+
+export default function MyPage() {
+  return (
+    <div>
+      <MyPageHeader />
+    </div>
+  );
+}

--- a/src/app/features/home/ImgWithTextAndBtns.tsx
+++ b/src/app/features/home/ImgWithTextAndBtns.tsx
@@ -6,11 +6,7 @@ import { Button } from "@/components/ui/button";
 import NoRightClickImg from "@/components/NoRightClickImg";
 import Image from "next/image";
 
-export const ImgWithTextAndBtns: React.FC<HomeProps> = ({
-  title,
-  text,
-  img,
-}) => {
+const ImgWithTextAndBtns: React.FC<HomeProps> = ({ title, text, img }) => {
   const router = useRouter();
 
   const handleNavigation = (link: string) => {
@@ -43,3 +39,5 @@ export const ImgWithTextAndBtns: React.FC<HomeProps> = ({
     </div>
   );
 };
+
+export default ImgWithTextAndBtns;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
+import dynamic from "next/dynamic";
 import { ImgWithTextLeft } from "@/app/features/home/ImgWithTextLeft";
 import { ImgWithTextRight } from "@/app/features/home/ImgWithTextRight";
-import { ImgWithTextAndBtns } from "@/app/features/home/ImgWithTextAndBtns";
 import { KeyFeatures } from "@/app/features/home/KeyFeatures";
+
+// 동적 import를 사용하여 컴포넌트를 클라이언트 사이드에서만 렌더링하도록 설정
+const ImgWithTextAndBtns = dynamic(
+  () => import("@/app/features/home/ImgWithTextAndBtns"),
+  { ssr: false },
+);
 
 const Home: React.FC = () => {
   return (
@@ -34,7 +40,7 @@ const Home: React.FC = () => {
         title="웹으로 즐기는 마피아 게임 | Chatfia"
         text="Mafia game enjoyed online."
         img="/imgs/index-5.png"
-        isTextLeft={true}
+        isTextLeft={false}
       />
       <KeyFeatures />
     </>


### PR DESCRIPTION
- 동적 import를 사용하여 ImgWithTextAndBtns 컴포넌트를 ssr: false로 설정
- ImgWithTextAndBtns 컴포넌트가 클라이언트 사이드에서만 렌더링되도록 수정