### PR TITLE
fix: 닉네임 변경 후 UI에 즉시 반영되지 않는 문제 수정

### DIFF
--- a/src/app/(route)/mypage/profile/page.tsx
+++ b/src/app/(route)/mypage/profile/page.tsx
@@ -17,7 +17,6 @@ export default function ProfilePage() {
   const { setUserInfo } = useUserStore();
   const { data, isLoading, isError, refetch } = useUserInfo();
 
-  // 여기에서 useNicknameStore로 닉네임을 가져옴
   const { nickname: updatedNickname } = useNicknameStore();
 
   const [isNicknameModalOpen, setIsNicknameModalOpen] = useState(false);
@@ -43,7 +42,7 @@ export default function ProfilePage() {
   ) : isError || !isSuccess ? (
     <TriangleAlert className="ml-2 h-8 w-8 text-red-400" />
   ) : (
-    <p>{updatedNickname || data?.nickname}</p> // 변경된 닉네임을 사용
+    <p>{updatedNickname || data?.nickname}</p>
   );
 
   // 이메일이 로딩 중이거나 에러가 발생했을 때의 처리

--- a/src/app/apis/authApi.ts
+++ b/src/app/apis/authApi.ts
@@ -20,6 +20,9 @@ export const authApi = {
   checkAuth: async () => {
     return fetchExtended("/api/auth/check", {
       method: "GET",
+      headers: {
+        "Cache-Control": "no-cache",
+      },
     });
   },
 

--- a/src/app/apis/hooks/useUpdateNickname.ts
+++ b/src/app/apis/hooks/useUpdateNickname.ts
@@ -5,13 +5,13 @@ import { authApi } from "@/app/apis/authApi";
 
 export const useUpdateNickname = () => {
   const setNickname = useNicknameStore((state) => state.setNickname);
-  const { setUserInfo } = useUserStore(); // UserStore의 setUserInfo 함수도 가져옴
+  const { setUserInfo } = useUserStore();
 
   return useMutation({
     mutationFn: authApi.updateNickname,
     onSuccess: (data) => {
       setNickname(data.newNickname);
-      setUserInfo(data.newNickname, data.email); // UserStore에 있는 정보 업데이트
+      setUserInfo(data.newNickname, data.email);
     },
     onError: (error) => {
       console.error("닉네임 수정 중 에러 발생:", error);

--- a/src/app/features/mypage/UpdateNicknameModal.tsx
+++ b/src/app/features/mypage/UpdateNicknameModal.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { updateNicknameSchema } from "@/app/validators/auth";
 import { useToast } from "@/components/ui/use-toast";
+import { useUserInfo } from "@/app/apis/hooks/useUserInfo";
 import { useUpdateNickname } from "@/app/apis/hooks/useUpdateNickname";
 import { X } from "lucide-react";
 
@@ -21,6 +22,7 @@ export const UpdateNicknameModal: React.FC<UpdateNicknameModalProps> = ({
   });
 
   const { toast } = useToast();
+  const { refetch } = useUserInfo();
   const updateNicknameMutation = useUpdateNickname();
 
   const onSubmit = (data: any) => {
@@ -31,6 +33,7 @@ export const UpdateNicknameModal: React.FC<UpdateNicknameModalProps> = ({
           variant: "success",
           duration: 3000,
         });
+        refetch();
         onSuccess(data.nickname);
         onClose();
       },


### PR DESCRIPTION
- 닉네임 변경 후 checkAuth API의 캐싱 문제를 해결하기 위해 no-cache 헤더 추가
- 닉네임 업데이트 후 사용자 정보를 강제로 새로고침(refetch)하도록 로직 수정